### PR TITLE
 Fix inject-by-tag when enumerating assets which source is not a string

### DIFF
--- a/dist/WebpackAutoInjectVersion.js
+++ b/dist/WebpackAutoInjectVersion.js
@@ -643,22 +643,32 @@ var InjectByTag = function () {
         for (var basename in compilation.assets) {
           // only if match regex
           if (_this.context.config.componentsOptions.InjectByTag.fileRegex.test(basename)) {
-            (function () {
+            var _ret = function () {
               var replaced = 0;
               var asset = compilation.assets[basename];
-              var modFile = asset.source().replace(/(\[AIV\]{version}\[\/AIV\])/g, function () {
+
+              var originalSource = asset.source();
+              if (!originalSource || typeof originalSource.replace !== 'function') {
+                return 'continue';
+              }
+
+              var modFile = originalSource.replace(/(\[AIV\]{version}\[\/AIV\])/g, function () {
                 replaced++;
                 return _this.context.version;
               });
+
               asset.source = function () {
                 return modFile;
               };
               _log2.default.info('InjectByTag : match : ' + basename + ' : replaced : ' + replaced);
-            })();
+            }();
+
+            if (_ret === 'continue') continue;
           }
         }
         cb();
       });
+
       return new _promise2.default(function (resolve, reject) {
         resolve();
       });

--- a/src/components/inject-by-tag.js
+++ b/src/components/inject-by-tag.js
@@ -21,16 +21,24 @@ export default class InjectByTag{
         if(this.context.config.componentsOptions.InjectByTag.fileRegex.test(basename)) {
           let replaced = 0;
           let asset = compilation.assets[basename];
-          let modFile = asset.source().replace(/(\[AIV\]{version}\[\/AIV\])/g, () => {
+
+          const originalSource = asset.source();
+          if (!originalSource || typeof originalSource.replace !== 'function') {
+            continue;
+          }
+
+          let modFile = originalSource.replace(/(\[AIV\]{version}\[\/AIV\])/g, () => {
             replaced++;
             return this.context.version;
           });
+
           asset.source = () => modFile;
           log.info(`InjectByTag : match : ${basename} : replaced : ${replaced}`);
         }
       }
       cb();
     });
+
     return new Promise((resolve, reject) => { resolve(); })
   }
 }


### PR DESCRIPTION
Some `assets.source()` return binary data arrays and should be skipped
Updated `InjectByTag` to skip handling of non string source

Fix #13 
