### PR TITLE
Add PACKAGE_JSON_INDENT setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ module.exports = {
         SHORT: 'CUSTOM',
         SILENT: false,
         PACKAGE_JSON_PATH: './package.json',
+        PACKAGE_JSON_INDENT: 4,
         components: {
           AutoIncreaseVersion: true,
           InjectAsComment: true,

--- a/src/components/auto-increase-version/auto-increase-version.js
+++ b/src/components/auto-increase-version/auto-increase-version.js
@@ -91,7 +91,7 @@ export default class AutoIncreaseVersion {
     this.packageFile.version = newVersion;
     fs.writeFile(
       path.resolve(this.context.config.PACKAGE_JSON_PATH),
-      JSON.stringify(this.packageFile, null, 4), (err) => {
+      JSON.stringify(this.packageFile, null, this.context.config.PACKAGE_JSON_INDENT), (err) => {
         if (err) {
           this.reject(err);
           console.log(err);

--- a/src/config.js
+++ b/src/config.js
@@ -2,6 +2,7 @@ export default {
   SHORT: 'AIV_SHORT',
   SILENT: false,
   PACKAGE_JSON_PATH: './package.json',
+  PACKAGE_JSON_INDENT: 4,
   components: {
     AutoIncreaseVersion: true,
     InjectAsComment: true,


### PR DESCRIPTION
Allow custom number of indent spaces when regenerating package.json file.

Note: I didn't recompile dist in this PR, since my build made a lot of other unrelated changes.