### PR TITLE
Use webpack-4 style hooks.

### DIFF
--- a/src/components/auto-increase-version/auto-increase-version.js
+++ b/src/components/auto-increase-version/auto-increase-version.js
@@ -32,7 +32,7 @@ export default class AutoIncreaseVersion {
     // we have to register AutoIncreaseVersion instead of firing it straight away
     if (config.componentsOptions.AutoIncreaseVersion.runInWatchMode) {
       if (this.context.compiler) {
-        this.context.compiler.plugin('emit', (compilation, cb) => {
+        this.context.compiler.hooks.emit.tap((compilation, cb) => {
           this.start();
           cb();
         });

--- a/src/components/inject-as-comment/inject-as-comment.js
+++ b/src/components/inject-as-comment/inject-as-comment.js
@@ -30,7 +30,7 @@ export default class InjectAsComment {
    */
   apply() {
     // bind into emit hook
-    this.context.compiler.plugin('emit', (compilation, cb) => {
+    this.context.compiler.hooks.emit.tap((compilation, cb) => {
       // iterate over all assets file in compilation
       for (const basename in compilation.assets) {
         // bug fix, extname is not able to handle chunk file params index.js?random123

--- a/src/components/inject-by-tag/inject-by-tag.js
+++ b/src/components/inject-by-tag/inject-by-tag.js
@@ -21,7 +21,7 @@ export default class InjectByTag {
    * @return {Promise}
    */
   apply() {
-    this.context.compiler.plugin('emit', (compilation, cb) => {
+    this.context.compiler.hooks.emit.tap((compilation, cb) => {
       // for every output file
       for (const basename in compilation.assets) {
         // only if match regex


### PR DESCRIPTION
`compiler.plugin` is deprecated in webpack 4. This PR uses the new way of hooking into webpack, fixing #32.

Context: I upgraded to webpack 4 today, and got this warning:

```
(node:8980) DeprecationWarning: Tapable.plugin is deprecated. Use new API on `.hooks` instead
    at InjectByTag.apply (<source path>\node_modules\webpack-auto-inject-version\dist\WebpackAutoInjectVersion.js:3468:29)
    at WebpackAutoInject._executeComponent (<source path>\node_modules\webpack-auto-inject-version\dist\WebpackAutoInjectVersion.js:2879:12)
    at WebpackAutoInject._executeComponent (<source path>\node_modules\webpack-auto-inject-version\dist\WebpackAutoInjectVersion.js:2871:14)
    at WebpackAutoInject._executeWebpackComponents (<source path>\node_modules\webpack-auto-inject-version\dist\WebpackAutoInjectVersion.js:2844:12)
    at WebpackAutoInject.apply (<source path>\node_modules\webpack-auto-inject-version\dist\WebpackAutoInjectVersion.js:2817:12)
    at webpack (<source path>\node_modules\webpack\lib\webpack.js:47:13)
    at Object.<anonymous> (C:\Work\Git\SqlClone\RedGate.SqlClone.Client.Web\tools\build.js:14:1)
    at Module._compile (module.js:653:30)
    at Object.Module._extensions..js (module.js:664:10)
    at Module.load (module.js:566:32)
    at tryModuleLoad (module.js:506:12)
    at Function.Module._load (module.js:498:3)
    at Function.Module.runMain (module.js:694:10)
    at startup (bootstrap_node.js:204:16)
    at bootstrap_node.js:625:3
```

I guess this would make webpack-auto-inject-version incompatible with webpack 3 and earlier; I'm not sure what the best way of dealing with that is.