### PR TITLE
Fixing 'DeprecationWarning: Tapable.plugin is deprecated. Use new API'

### DIFF
--- a/dist/WebpackAutoInjectVersion.js
+++ b/dist/WebpackAutoInjectVersion.js
@@ -3066,7 +3066,7 @@ var AutoIncreaseVersion = function () {
       // we have to register AutoIncreaseVersion instead of firing it straight away
       if (_config2.default.componentsOptions.AutoIncreaseVersion.runInWatchMode) {
         if (this.context.compiler) {
-          this.context.compiler.plugin('emit', function (compilation, cb) {
+          this.context.compiler.hooks.emit.tapAsync('EmitAutoIncreaseVersion', function (compilation, cb) {
             _this.start();
             cb();
           });
@@ -3276,7 +3276,7 @@ var InjectAsComment = function () {
       var _this = this;
 
       // bind into emit hook
-      this.context.compiler.plugin('emit', function (compilation, cb) {
+      this.context.compiler.hooks.emit.tapAsync('EmitInjectAsComment', function (compilation, cb) {
         // iterate over all assets file in compilation
         for (var basename in compilation.assets) {
           // bug fix, extname is not able to handle chunk file params index.js?random123
@@ -3508,7 +3508,7 @@ var InjectByTag = function () {
     value: function apply() {
       var _this = this;
 
-      this.context.compiler.plugin('emit', function (compilation, cb) {
+      this.context.compiler.hooks.emit.tapAsync('EmitInjectByTag', function (compilation, cb) {
         // for every output file
         for (var basename in compilation.assets) {
           // only if match regex

--- a/src/components/auto-increase-version/auto-increase-version.js
+++ b/src/components/auto-increase-version/auto-increase-version.js
@@ -32,7 +32,7 @@ export default class AutoIncreaseVersion {
     // we have to register AutoIncreaseVersion instead of firing it straight away
     if (config.componentsOptions.AutoIncreaseVersion.runInWatchMode) {
       if (this.context.compiler) {
-        this.context.compiler.plugin('emit', (compilation, cb) => {
+        this.context.compiler.hooks.emit.tapAsync('EmitAutoIncreaseVersion', (compilation, cb) => {
           this.start();
           cb();
         });

--- a/src/components/inject-as-comment/inject-as-comment.js
+++ b/src/components/inject-as-comment/inject-as-comment.js
@@ -30,7 +30,7 @@ export default class InjectAsComment {
    */
   apply() {
     // bind into emit hook
-    this.context.compiler.plugin('emit', (compilation, cb) => {
+    this.context.compiler.hooks.emit.tapAsync('EmitInjectAsComment', (compilation, cb) => {
       // iterate over all assets file in compilation
       for (const basename in compilation.assets) {
         // bug fix, extname is not able to handle chunk file params index.js?random123

--- a/src/components/inject-by-tag/inject-by-tag.js
+++ b/src/components/inject-by-tag/inject-by-tag.js
@@ -21,7 +21,7 @@ export default class InjectByTag {
    * @return {Promise}
    */
   apply() {
-    this.context.compiler.plugin('emit', (compilation, cb) => {
+    this.context.compiler.hooks.emit.tapAsync('EmitInjectByTag', (compilation, cb) => {
       // for every output file
       for (const basename in compilation.assets) {
         // only if match regex


### PR DESCRIPTION
This message is not just warning without additional settings webpack will actually cause Production build to fail. The similar PR #41 has a wrong syntax this PR should fix that.

Could you guys make a new build ?