### PR TITLE
updating packages for webpack 5 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,9 @@ to prevent stripping out AIV comments eg:
 ```
 
 # Change log
+
+## [1.2.3] - 09/06/2021
+ - updates for webpack 5 comatibility
 ## [1.2.2] - 27/10/2018
 - add PACKAGE_JSON_INDENT @trevyn
 ## [1.2.1] - 27/10/2018

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webpack-auto-inject-version",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "repository": "radswiat/webpack-auto-inject-version",
   "description": "Webpack plugin for auto inject version from package.json",
   "main": "dist/WebpackAutoInjectVersion.js",
@@ -37,7 +37,7 @@
     "lodash": "^4.17.11",
     "optimist": "^0.6.1",
     "semver": "^5.3.0",
-    "webpack": "^2.3.3",
+    "webpack": "^5.38.1",
     "webpack-node-externals": "^1.5.4"
   }
 }

--- a/src/components/auto-increase-version/auto-increase-version.js
+++ b/src/components/auto-increase-version/auto-increase-version.js
@@ -32,7 +32,7 @@ export default class AutoIncreaseVersion {
     // we have to register AutoIncreaseVersion instead of firing it straight away
     if (config.componentsOptions.AutoIncreaseVersion.runInWatchMode) {
       if (this.context.compiler) {
-        this.context.compiler.plugin('emit', (compilation, cb) => {
+        this.context.compiler.hooks.emit.tapAsync('emit', (compilation, cb) => {
           this.start();
           cb();
         });

--- a/src/components/inject-as-comment/inject-as-comment.js
+++ b/src/components/inject-as-comment/inject-as-comment.js
@@ -30,7 +30,7 @@ export default class InjectAsComment {
    */
   apply() {
     // bind into emit hook
-    this.context.compiler.plugin('emit', (compilation, cb) => {
+    this.context.compiler.hooks.emit.tapAsync('emit', (compilation, cb) => {
       // iterate over all assets file in compilation
       for (const basename in compilation.assets) {
         // bug fix, extname is not able to handle chunk file params index.js?random123

--- a/src/components/inject-by-tag/inject-by-tag.js
+++ b/src/components/inject-by-tag/inject-by-tag.js
@@ -21,7 +21,7 @@ export default class InjectByTag {
    * @return {Promise}
    */
   apply() {
-    this.context.compiler.plugin('emit', (compilation, cb) => {
+    this.context.compiler.hooks.emit.tapAsync('emit', (compilation, cb) => {
       // for every output file
       for (const basename in compilation.assets) {
         // only if match regex


### PR DESCRIPTION
webpack 5 has a new object structure. This specific change was causing the build to fail so. Adding those changes in this PR for future use.
https://webpack.js.org/contribute/writing-a-plugin/
@radswiat 